### PR TITLE
Fetch request gets blocked/delayed in browser

### DIFF
--- a/src/AllMonstersList.js
+++ b/src/AllMonstersList.js
@@ -9,7 +9,7 @@ export default function AllMonstersList() {
       .then((res) => res.json())
       .then((data) => setMonsterList(data.results))
       .catch((err) => console.log(err))
-  })
+  }, [])
   return (
     <>
       <HeadlineStyled>Monsters of DnD</HeadlineStyled>


### PR DESCRIPTION
This pull request is linked to Userstory #4 

For my Project I am fetching a List from an open API. The initial loading time is unbearably long with up to 10 seconds.

During that time the console shows the following: 
```[HMR] Waiting for update signal from WDS...```

<img width="560" alt="Bildschirmfoto 2020-09-01 um 10 12 29" src="https://user-images.githubusercontent.com/67914612/91826375-c6c23d00-ec3d-11ea-96c6-02317ab7b105.png">

while the network tab of the developer-tools shows this:

<img width="894" alt="Bildschirmfoto 2020-09-01 um 10 13 24" src="https://user-images.githubusercontent.com/67914612/91826445-e0fc1b00-ec3d-11ea-8b07-f2360579cc01.png">

As you can see in the last Screenshot, the data eventually loads correctly in the browser window.

Do i have to adjust my code to not trigger the block or is this a browser issue?